### PR TITLE
Add jscpd duplicate code check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,8 +49,10 @@ code-duplication:
       when: always
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       when: manual
+  before_script:
+    - apk add --no-cache jq curl
   script:
-    - ./scripts/run-jscpd.sh
+    - ./scripts/jscpd-ci.sh
   allow_failure: false
 
 # Main MR summarizer job

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,18 @@ test-configuration:
     - python scripts/test_gitlab_ci.py
   allow_failure: true
 
+code-duplication:
+  stage: test
+  image: node:20-alpine
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: always
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+  script:
+    - ./scripts/run-jscpd.sh
+  allow_failure: false
+
 # Main MR summarizer job
 mr-summarizer:
   stage: summarize

--- a/scripts/jscpd-ci.sh
+++ b/scripts/jscpd-ci.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+EXIT_CODE=0
+./scripts/run-jscpd.sh || EXIT_CODE=$?
+./scripts/post-jscpd-comment.sh || true
+exit $EXIT_CODE

--- a/scripts/post-jscpd-comment.sh
+++ b/scripts/post-jscpd-comment.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+REPORT="jscpd-report/jscpd-report.json"
+
+# Skip if report or required env vars are missing
+if [ ! -f "$REPORT" ]; then
+  echo "No jscpd report found, skipping comment"
+  exit 0
+fi
+
+: "${CI_PROJECT_ID:=}"
+: "${CI_MERGE_REQUEST_IID:=}"
+: "${CI_API_V4_URL:=}"
+: "${GITLAB_PERSONAL_TOKEN:=}"
+
+if [ -z "$CI_PROJECT_ID" ] || [ -z "$CI_MERGE_REQUEST_IID" ] || \
+   [ -z "$CI_API_V4_URL" ] || [ -z "$GITLAB_PERSONAL_TOKEN" ]; then
+  echo "Missing GitLab environment variables, skipping comment"
+  exit 0
+fi
+
+dup_lines=$(jq '.statistics.total.duplicatedLines' "$REPORT")
+clones=$(jq '.statistics.total.clones' "$REPORT")
+lines=$(jq '.statistics.total.lines' "$REPORT")
+percent=$(jq '.statistics.total.percentage' "$REPORT")
+
+comment=$(printf '🧬 **jscpd Report**\n\n- Clones: %s\n- Duplicated lines: %s / %s (%.2f%%)' "$clones" "$dup_lines" "$lines" "$percent")
+
+curl --silent --show-error --fail \
+  --request POST \
+  --header "PRIVATE-TOKEN: $GITLAB_PERSONAL_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data "$(jq -n --arg body "$comment" '{body: $body}')" \
+  "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"

--- a/scripts/run-jscpd.sh
+++ b/scripts/run-jscpd.sh
@@ -1,3 +1,11 @@
 #!/bin/sh
 set -eu
-npx --yes jscpd --min-lines 5 --reporters console --threshold 1 "$@"
+
+# Run jscpd with console and json reporters so results can be parsed later.
+# Reports are written to the default "jscpd-report" directory.
+npx --yes jscpd \
+  --min-lines 5 \
+  --reporters console,json \
+  --output jscpd-report \
+  --threshold 1 \
+  "$@"

--- a/scripts/run-jscpd.sh
+++ b/scripts/run-jscpd.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+npx --yes jscpd --min-lines 5 --reporters console --threshold 1 "$@"

--- a/test/readme.md
+++ b/test/readme.md
@@ -14,4 +14,4 @@ The script uses `npx` to download jscpd if necessary and scans the repository. T
 
 ## CI integration
 
-The `.gitlab-ci.yml` includes a `code-duplication` job in the `test` stage that runs the same script to prevent duplicated code from entering the repository.
+The `.gitlab-ci.yml` includes a `code-duplication` job in the `test` stage that runs the same script to prevent duplicated code from entering the repository. When triggered for a merge request, the job also posts a short summary of the scan back to the MR as a comment.

--- a/test/readme.md
+++ b/test/readme.md
@@ -1,0 +1,17 @@
+# Duplicate Code Check
+
+This repository uses [jscpd](https://github.com/kucherenko/jscpd) to detect duplicated code.
+
+## Run locally
+
+Make sure you have Node.js installed. Then run:
+
+```sh
+./scripts/run-jscpd.sh
+```
+
+The script uses `npx` to download jscpd if necessary and scans the repository. The command exits with a non‑zero status when duplicates are found.
+
+## CI integration
+
+The `.gitlab-ci.yml` includes a `code-duplication` job in the `test` stage that runs the same script to prevent duplicated code from entering the repository.


### PR DESCRIPTION
## Summary
- add `code-duplication` CI job running jscpd
- add script `run-jscpd.sh` for local duplicate scanning
- document duplicate code checks in `test/readme.md`

## Testing
- `./scripts/run-jscpd.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a78a9d8a4c8324819dfcc88b13afed