### PR TITLE
Add scripts for jscpd merge reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/settings.json
+jscpd-*.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - debug
   - test
+  - code_quality
   - summarize
 
 debug-env:
@@ -40,6 +41,26 @@ test-configuration:
   script:
     - python scripts/test_gitlab_ci.py
   allow_failure: true
+
+# jscpd duplicate code check
+jscpd-merge:
+  stage: code_quality
+  image: node:20
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+      when: always
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+  before_script:
+    - apt-get update && apt-get install -y git jq
+    - git config --global --add safe.directory $CI_PROJECT_DIR
+  script:
+    - scripts/run-jscpd-merge.sh
+    - scripts/post-jscpd-merge-comment.sh
+  allow_failure: true
+  needs:
+    - job: test-configuration
+      optional: true
 
 # Main MR summarizer job
 mr-summarizer:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project provides a **zero-infrastructure** solution for automatically gener
 - ✅ **Error Handling** - Graceful failure with informative error comments
 - ✅ **Large Diff Support** - Intelligent chunking and simplification for large changes
 - ✅ **Retry Logic** - Automatic retries for transient failures
+- ✅ **Duplicate Code Reports** - jscpd compares base and merged code and posts MR comments
 
 ## 🚀 Quick Start
 
@@ -43,6 +44,25 @@ Go to your project **Settings → CI/CD → Variables** and add:
 
 ### 4. Test
 Create a merge request with code changes and watch the AI summary appear automatically!
+
+### 5. Duplicate Code Report (optional)
+A `jscpd` job compares duplicate lines between the target branch and the merge
+result. It runs in the `code_quality` stage and posts a Markdown table to the
+merge request.
+
+To try it locally:
+
+```bash
+./scripts/run-jscpd-merge.sh
+CI_API_V4_URL=https://gitlab.com/api/v4 \
+CI_PROJECT_ID=123 \
+CI_MERGE_REQUEST_IID=1 \
+GITLAB_PERSONAL_TOKEN=your-token \
+./scripts/post-jscpd-merge-comment.sh
+```
+
+The scripts generate `jscpd-base.json` and `jscpd-merged.json` and clean up
+their temporary worktrees. The JSON files are ignored by git.
 
 ## 🔧 How It Works
 
@@ -80,6 +100,8 @@ The pipeline automatically:
 ├── .gitlab-ci.yml                    # CI/CD pipeline configuration
 ├── scripts/
 │   ├── gitlab_ci_summarizer.py       # Main summarizer script
+│   ├── post-jscpd-merge-comment.sh   # Post duplicate code table to MR
+│   ├── run-jscpd-merge.sh            # Generate jscpd reports for base/merged code
 │   └── test_gitlab_ci.py             # Configuration test script
 └── README.md                         # This file
 ```

--- a/scripts/post-jscpd-merge-comment.sh
+++ b/scripts/post-jscpd-merge-comment.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_FILE="jscpd-base.json"
+MERGED_FILE="jscpd-merged.json"
+
+if [[ ! -f "$BASE_FILE" || ! -f "$MERGED_FILE" ]]; then
+  echo "Missing jscpd JSON files" >&2
+  exit 1
+fi
+
+FORMATS=$(jq -r '.statistics.formats | keys[]' "$BASE_FILE" "$MERGED_FILE" | sort -u)
+TABLE="| Format | Base Duplicated Lines | Base % | Merged Duplicated Lines | Merged % |\n|---|---|---|---|---|"
+for fmt in $FORMATS; do
+  base_dup=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.duplicatedLines // 0' "$BASE_FILE")
+  base_pct=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.percentage // 0' "$BASE_FILE")
+  merged_dup=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.duplicatedLines // 0' "$MERGED_FILE")
+  merged_pct=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.percentage // 0' "$MERGED_FILE")
+  TABLE="$TABLE\n| $fmt | $base_dup | ${base_pct}% | $merged_dup | ${merged_pct}% |"
+done
+
+COMMENT="### jscpd duplicate code report\n\n$TABLE"
+
+: "${CI_API_V4_URL?CI_API_V4_URL not set}"
+: "${CI_PROJECT_ID?CI_PROJECT_ID not set}"
+: "${CI_MERGE_REQUEST_IID?CI_MERGE_REQUEST_IID not set}"
+: "${GITLAB_PERSONAL_TOKEN?GITLAB_PERSONAL_TOKEN not set}"
+
+curl --header "PRIVATE-TOKEN: $GITLAB_PERSONAL_TOKEN" \
+     --data-urlencode "body=$(printf '%s' "$COMMENT")" \
+     "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"

--- a/scripts/post-jscpd-merge-comment.sh
+++ b/scripts/post-jscpd-merge-comment.sh
@@ -10,16 +10,20 @@ if [[ ! -f "$BASE_FILE" || ! -f "$MERGED_FILE" ]]; then
 fi
 
 FORMATS=$(jq -r '.statistics.formats | keys[]' "$BASE_FILE" "$MERGED_FILE" | sort -u)
-TABLE="| Format | Base Duplicated Lines | Base % | Merged Duplicated Lines | Merged % |\n|---|---|---|---|---|"
+TABLE="| Format | Base Duplicated Lines | Base % | Merged Duplicated Lines | Merged % |
+|---|---|---|---|---|"
 for fmt in $FORMATS; do
   base_dup=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.duplicatedLines // 0' "$BASE_FILE")
   base_pct=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.percentage // 0' "$BASE_FILE")
   merged_dup=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.duplicatedLines // 0' "$MERGED_FILE")
   merged_pct=$(jq -r --arg f "$fmt" '.statistics.formats[$f].total.percentage // 0' "$MERGED_FILE")
-  TABLE="$TABLE\n| $fmt | $base_dup | ${base_pct}% | $merged_dup | ${merged_pct}% |"
+  TABLE="$TABLE
+| $fmt | $base_dup | ${base_pct}% | $merged_dup | ${merged_pct}% |"
 done
 
-COMMENT="### jscpd duplicate code report\n\n$TABLE"
+COMMENT="### jscpd duplicate code report
+
+$TABLE"
 
 : "${CI_API_V4_URL?CI_API_V4_URL not set}"
 : "${CI_PROJECT_ID?CI_PROJECT_ID not set}"
@@ -27,5 +31,5 @@ COMMENT="### jscpd duplicate code report\n\n$TABLE"
 : "${GITLAB_PERSONAL_TOKEN?GITLAB_PERSONAL_TOKEN not set}"
 
 curl --header "PRIVATE-TOKEN: $GITLAB_PERSONAL_TOKEN" \
-     --data-urlencode "body=$(printf '%s' "$COMMENT")" \
+     --data-urlencode "body=$(printf '%b' "$COMMENT")" \
      "$CI_API_V4_URL/projects/$CI_PROJECT_ID/merge_requests/$CI_MERGE_REQUEST_IID/notes"

--- a/scripts/run-jscpd-merge.sh
+++ b/scripts/run-jscpd-merge.sh
@@ -5,6 +5,13 @@ TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-main}"
 BASE_WORKTREE="jscpd-base-worktree"
 MERGED_WORKTREE="jscpd-merged-worktree"
 
+# Ensure we have the latest target branch when a remote is available
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch origin "$TARGET_BRANCH" >/dev/null
+else
+  echo "No remote named 'origin'; skipping fetch" >&2
+fi
+
 # Determine reference for target branch
 if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
   TARGET_REF="origin/$TARGET_BRANCH"
@@ -20,13 +27,6 @@ cleanup() {
   git worktree remove "$MERGED_WORKTREE" --force 2>/dev/null || true
 }
 trap cleanup EXIT
-
-# Ensure we have the latest target branch when a remote is available
-if git remote get-url origin >/dev/null 2>&1; then
-  git fetch origin "$TARGET_BRANCH" >/dev/null
-else
-  echo "No remote named 'origin'; skipping fetch" >&2
-fi
 
 # Run jscpd on the base branch
 git worktree add "$BASE_WORKTREE" "$TARGET_REF"

--- a/scripts/run-jscpd-merge.sh
+++ b/scripts/run-jscpd-merge.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_BRANCH="${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-main}"
+BASE_WORKTREE="jscpd-base-worktree"
+MERGED_WORKTREE="jscpd-merged-worktree"
+
+# Determine reference for target branch
+if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_BRANCH"; then
+  TARGET_REF="origin/$TARGET_BRANCH"
+elif git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+  TARGET_REF="$TARGET_BRANCH"
+else
+  echo "Target branch $TARGET_BRANCH not found" >&2
+  exit 1
+fi
+
+cleanup() {
+  git worktree remove "$BASE_WORKTREE" --force 2>/dev/null || true
+  git worktree remove "$MERGED_WORKTREE" --force 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Ensure we have the latest target branch when a remote is available
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch origin "$TARGET_BRANCH" >/dev/null
+else
+  echo "No remote named 'origin'; skipping fetch" >&2
+fi
+
+# Run jscpd on the base branch
+git worktree add "$BASE_WORKTREE" "$TARGET_REF"
+(
+  cd "$BASE_WORKTREE"
+  npx --yes jscpd --reporters json --output jscpd-report . >/dev/null
+  mv jscpd-report/jscpd-report.json ../jscpd-base.json
+)
+
+# Run jscpd on the merged code (current HEAD merged with target branch)
+git worktree add --detach "$MERGED_WORKTREE" HEAD
+(
+  cd "$MERGED_WORKTREE"
+  git merge --no-commit --no-ff "$TARGET_REF" >/dev/null
+  npx --yes jscpd --reporters json --output jscpd-report . >/dev/null
+  mv jscpd-report/jscpd-report.json ../jscpd-merged.json
+)


### PR DESCRIPTION
## Summary
- add run-jscpd-merge.sh to generate base and merged jscpd reports using temporary worktrees
- add post-jscpd-merge-comment.sh to format jscpd results and post them to the merge request

## Testing
- `./scripts/run-jscpd-merge.sh`
- `CI_API_V4_URL=https://httpbin.org CI_PROJECT_ID=1 CI_MERGE_REQUEST_IID=1 GITLAB_PERSONAL_TOKEN=dummy ./scripts/post-jscpd-merge-comment.sh` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b71a8f0c8324b868a63fbf6d987b