### PR TITLE
feat: add diff filtering with path allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 This project provides a **zero-infrastructure** solution for automatically generating AI summaries of GitLab merge requests using StackSpot AI, running entirely within GitLab's CI/CD pipeline.
 
+## Table of Contents
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [How It Works](#how-it-works)
+- [Project Structure](#project-structure)
+- [Advanced Setup](#advanced-setup)
+- [Comparison with AWS Version](#comparison-with-aws-version)
+- [Diff Filtering](#diff-filtering)
+- [Troubleshooting](#troubleshooting)
+- [Monitoring and Performance](#monitoring-and-performance)
+- [Requirements](#requirements)
+- [Support](#support)
+- [Success](#success)
+
 ## ✨ Features
 
 - ✅ **Zero Infrastructure** - No AWS services or external hosting required
@@ -188,6 +202,21 @@ rules:
 | **Deployment** | Terraform + ECS | Git push |
 | **Latency** | ~1-2 seconds | < 1 second |
 | **Maintenance** | High | Zero |
+
+## 🧹 Diff Filtering
+
+Control which files are summarized by editing `should_include` in
+`scripts/gitlab_ci_summarizer.py`. Only paths that return `True` are sent to
+StackSpot AI.
+
+```python
+def should_include(path: str) -> bool:
+    allowed_prefixes = ["src/", "docs/"]
+    return any(path.startswith(p) for p in allowed_prefixes)
+```
+
+For testability, `filter_changed_files` accepts a custom predicate, letting you
+inject different allow/deny rules when needed.
 
 ## 🔍 Troubleshooting
 

--- a/scripts/test_gitlab_ci.py
+++ b/scripts/test_gitlab_ci.py
@@ -271,7 +271,28 @@ def test_stackspot_credentials():
         logger.info(f"   Client Secret: {client_secret[:4]}...{client_secret[-4:]} ({len(client_secret)} chars)")
     if client_realm:
         logger.info(f"   Realm: {client_realm}")
-    
+
+    return True
+
+def test_filter_changed_files():
+    """Verify file filtering logic with mock data."""
+    from gitlab_ci_summarizer import filter_changed_files
+
+    mock_files = [
+        {'status': 'M', 'path': 'src/app.py'},
+        {'status': 'A', 'path': 'README.md'},
+        {'status': 'D', 'path': 'src/old.py'},
+        {'status': 'R100', 'old': 'src/old_name.py', 'new': 'src/new_name.py'},
+    ]
+
+    def mock_should_include(path):
+        return path.startswith('src/')
+
+    allowed = filter_changed_files(mock_files, mock_should_include)
+    expected = ['src/app.py', 'src/old.py', 'src/new_name.py']
+
+    assert allowed == expected, f"Expected {expected}, got {allowed}"
+    logger.info("✅ Filtering logic works as expected")
     return True
 
 def main():
@@ -283,7 +304,8 @@ def main():
         test_environment_variables,
         test_imports,
         test_gitlab_api_access,
-        test_stackspot_credentials
+        test_stackspot_credentials,
+        test_filter_changed_files
     ]
     
     passed = 0


### PR DESCRIPTION
## Summary
- filter commit diff paths using should_include and handle renames/deletions
- expose file filtering logic for testing
- add unit test exercising filter_changed_files
- document diff filtering and add table of contents to README

## Testing
- `pytest scripts/test_gitlab_ci.py::test_filter_changed_files -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31c0d5e7c83249a2bfb1c2a433045