### PR TITLE
Use merge-based jscpd scripts in CI

### DIFF
--- a/scripts/jscpd-ci.sh
+++ b/scripts/jscpd-ci.sh
@@ -2,8 +2,8 @@
 set -eu
 
 # EXIT_CODE=0
-# ./scripts/run-jscpd.sh || EXIT_CODE=$?
-./scripts/run-jscpd.sh || true
-./scripts/post-jscpd-comment.sh || true
+# ./scripts/run-jscpd-merge.sh || EXIT_CODE=$?
+./scripts/run-jscpd-merge.sh || true
+./scripts/post-jscpd-merge-comment.sh || true
 rm -rf jscpd-report jscpd-base.json jscpd-merged.json
 # exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- switch CI jscpd script to merge-based version
- post merge duplicate report comment

## Testing
- `python scripts/test_gitlab_ci.py` *(fails: No module named 'requests'; missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c33174518883248fb40626f544b394