### PR TITLE
feat: include jscpd table in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,13 @@ Create a merge request with code changes and watch the AI summary appear automat
 
 ### 5. Duplicate Code Report (optional)
 A `jscpd` job compares duplicate lines between the target branch and the merge
-result. It runs in the `code_quality` stage and posts a Markdown table to the
-merge request. Comments now list which files were analyzed and which were
-ignored:
+result. It runs in the `code_quality` stage and posts a Markdown table of any
+duplicated blocks to the merge request:
 
 ```markdown
-**Analyzed files**
-- src/app.py
-- src/utils/helpers.py
-
-**Ignored files**
-- test/test_app.py
+| Lines | First File | Second File |
+|---|---|---|
+| 12 | src/app.py:10-21 | src/utils/helpers.py:42-53 |
 ```
 
 To try it locally:


### PR DESCRIPTION
## Summary
- add duplicate block table to jscpd comment script
- drop diff filter handling from jscpd comments
- document new jscpd table output in README

## Testing
- `pytest -q scripts/test_gitlab_ci.py` (fails: fixture 'gitlab_api_url' not found)
- `pytest -q test/stress-test-duplicates/test_gitlab_ci.py` (fails: fixture 'gitlab_api_url' not found)


------
https://chatgpt.com/codex/tasks/task_e_68c344ba37f08324988415d6236682cd